### PR TITLE
shebang was hardwired to /usr/bin/python

### DIFF
--- a/undocker.py
+++ b/undocker.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import argparse
 import json


### PR DESCRIPTION
but it may be somewhere else, especially on CoreOS