### PR TITLE
Handle image names that contain repository host + port number

### DIFF
--- a/undocker.py
+++ b/undocker.py
@@ -88,17 +88,18 @@ def main():
                         ' '.join(tags))
                 sys.exit(0)
 
-            if not args.image:
-                if len(repos) == 1:
-                    args.image = repos.keys()[0]
-                else:
-                    LOG.error('No image name specified and multiple '
-                              'images contained in archive')
-                    sys.exit(1)
-            try:
-                name, tag = args.image.split(':', 1)
-            except ValueError:
-                name, tag = args.image, 'latest'
+            if args.image:
+                try:
+                    name, tag = args.image.rsplit(':', 1)
+                except ValueError:
+                    name, tag = args.image, 'latest'
+            elif len(repos) == 1:
+                name = repos.keys()[0]
+                tag = repos[name].keys()[0]
+            else:
+                LOG.error('No image name specified and multiple '
+                          'images contained in archive')
+                sys.exit(1)
 
             try:
                 top = repos[name][tag]

--- a/undocker.py
+++ b/undocker.py
@@ -66,6 +66,19 @@ def find_layers(img, id):
             yield layer
 
 
+def parse_image_spec(image):
+    try:
+        path, base = image.rsplit('/', 1)
+    except ValueError:
+        path, base = None, image
+    try:
+        name, tag = base.rsplit(':', 1)
+    except ValueError:
+        name, tag = base, 'latest'
+    name = path + '/' + name if path else name
+    return name, tag
+
+
 def main():
     args = parse_args()
     logging.basicConfig(level=args.loglevel)
@@ -89,10 +102,7 @@ def main():
                 sys.exit(0)
 
             if args.image:
-                try:
-                    name, tag = args.image.rsplit(':', 1)
-                except ValueError:
-                    name, tag = args.image, 'latest'
+                name, tag = parse_image_spec(args.image)
             elif len(repos) == 1:
                 name = repos.keys()[0]
                 tag = repos[name].keys()[0]


### PR DESCRIPTION
Fix for #11.

A quick explanation of changes:
1. When no image is specified on the command line and there is only one in the archive, choose the first tag for that image.
2. When an image is specified on the command line, the (much simplified) logic for parsing the value is:
   1. A `:` that appears after the last `/` separates the tag from the image name (if there's no tag, fall back to 'latest', as before).
   2. A `:` that appears before the last `/` is part of the image name (strictly, `:` is only allowed before the first `/` as part of a hostname, but that's not important for this use case).
