### PR TITLE
Fix failure trying to rmtree symlink to dir

### DIFF
--- a/undocker.py
+++ b/undocker.py
@@ -166,7 +166,7 @@ def main():
                                     LOG.info('removing path %s', newpath)
                                     os.unlink(path)
 
-                                    if os.path.isdir(newpath):
+                                    if os.path.isdir(newpath) and not os.path.islink(newpath):
                                         shutil.rmtree(newpath)
                                     else:
                                         os.unlink(newpath)


### PR DESCRIPTION
I'm sorry. Opened PR directly to upstream and didn't recognize that. However, it may be beneficial here too.

The problem is, `newpath` that's being deleted is a symbolic link to a non empty directory the command fails. This is because `isdir` follows symlinks, but `shutil.rmtree` not. 

Incase, if `newdir` is symlink, use `unlink()` insetad of `shutil.rmtree`