### PR TITLE
Add --manifest and --config

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,11 @@ Unpacks a Docker image.
       --verbose, -v
       --debug, -d
       --list, --ls          List layers in an image
+      --manifest, -m        Dump manifest contained in archive
       --layer LAYER, -l LAYER
                             Extract only the specified layer
+      --config, -c          Dump config contained in archive
+      --pretty, -p          Pretty print the json dump output
 
 ## Examples
 


### PR DESCRIPTION
For showing the raw manifest and the image config, both in json.
Add basic pretty-printing, for advanced topics one can use "`jq`".