### PR TITLE
docker save gzip fix

### DIFF
--- a/undocker.py
+++ b/undocker.py
@@ -120,7 +120,7 @@ def main():
                                     LOG.info('removing path %s', newpath)
                                     os.unlink(path)
 
-                                    if os.path.isdir(newpath):
+                                    if os.path.isdir(newpath) and not os.path.islink(newpath):
                                         shutil.rmtree(newpath)
                                     else:
                                         os.unlink(newpath)


### PR DESCRIPTION
Added logic for handling newer versions of 'docker save' that compress Layers to gzip.

Updates were added to the undocker.py version inside the AuterionOS repo (branch: release/4.1.2-auterion-simulator), which appears to forgo the find_layers function.

Tested on both versions of docker